### PR TITLE
"Memleak" in test-script for memleak ...

### DIFF
--- a/Leak-Hunting/eg/01.pod
+++ b/Leak-Hunting/eg/01.pod
@@ -52,6 +52,7 @@ only work on Linux due to checking /proc for the memory usage.
 
     my $mech = Test::WWW::Mechanize::PSGI->new(
         app => $app,
+        stack_depth => 0,
     );
 
     my $start_mem = get_mem();

--- a/Leak-Hunting/loop_requests.pl
+++ b/Leak-Hunting/loop_requests.pl
@@ -10,6 +10,7 @@ my $app = Plack::Util::load_psgi "${Bin}/myapp.psgi";
 
 my $mech = Test::WWW::Mechanize::PSGI->new(
     app => $app,
+    stack_depth => 0,
 );
 
 my $start_mem = get_mem();


### PR DESCRIPTION
OK, this is not really a memleak, but the $mech-object keeps a history up to 8675309 entries and for normal sites this can get huge!
-> for testing memleaks we don't need the $mech history

---

I was hunting a memleak with the code from Leak-Hunting in my app and at the end, after many hours spend i was totally confused that the memleak must be in Template::Toolkit! After adding many whitespaces to a template, the memleak gets bigger.

After some sleep and thinking about the test script i found the "memleak" in 3 minutes. Keeping all the rendered stuff alive in the $mech object won't help to find memleaks. So i added a "don't keep history" option to the $mech object and now i don't have a memleak anymore!

From the documentation of WWW::Mechanize:

=head2 $mech->stack_depth( $max_depth )

Get or set the page stack depth. Use this if you're doing a lot of page
scraping and running out of memory.

A value of 0 means "no history at all."  By default, the max stack depth
is humongously large, effectively keeping all history.
